### PR TITLE
fix(CIV-542): Glossary sample template url changed

### DIFF
--- a/app/views/admin/wordindices/index.html.slim
+++ b/app/views/admin/wordindices/index.html.slim
@@ -37,7 +37,7 @@
           .modal-body
                   .row.form-group.string.optional
                     .col-md-12.form-label-group
-                      = link_to 'Click to download sample template' , "https://civis-production-api.s3.ap-south-1.amazonaws.com/Civis+-+Response+Import+Template.xlsx"
+                      = link_to 'Click to download sample template' , "https://civis-production-api.s3.ap-south-1.amazonaws.com/glossary-template.csv"
                     .col-md-10.form-label-group
                       = f.file_field :file, class: "p10"
                     #loader-for-file-upload.col-md-2.form-label-group.hidden


### PR DESCRIPTION
## What?
Changed the link for downloading wordindices template

