### PR TITLE
FIX: import error fix

### DIFF
--- a/app/models/concerns/import_glossary.rb
+++ b/app/models/concerns/import_glossary.rb
@@ -41,7 +41,7 @@ module ImportGlossary
       if content_type.include?('csv')
         csv_file = open(file.path)
         csv_file = csv_file.string rescue csv_file.read
-        csv_file = csv_file.force_encoding("UTF-8").sub("\xEF\xBB\xBF", '')
+        csv_file = csv_file.encode("UTF-8", 'Windows-1252').sub("\xEF\xBB\xBF", '')
       else
         begin
           xlsx = Roo::Spreadsheet.open(file.path, extension: :xlsx)

--- a/app/models/concerns/import_profanities.rb
+++ b/app/models/concerns/import_profanities.rb
@@ -41,7 +41,7 @@ module ImportProfanities
       if content_type.include?('csv')
         csv_file = open(file.path)
         csv_file = csv_file.string rescue csv_file.read
-        csv_file = csv_file.force_encoding("UTF-8").sub("\xEF\xBB\xBF", '')
+        csv_file = csv_file.encode("UTF-8", 'Windows-1252').sub("\xEF\xBB\xBF", '')
       else
         begin
           xlsx = Roo::Spreadsheet.open(file.path, extension: :xlsx)

--- a/app/models/concerns/import_response.rb
+++ b/app/models/concerns/import_response.rb
@@ -35,7 +35,7 @@ module ImportResponse
       if content_type.include?('csv')
         csv_file = open(file.path)
         csv_file = csv_file.string rescue csv_file.read
-        csv_file = csv_file.force_encoding("UTF-8").sub("\xEF\xBB\xBF", '')
+        csv_file = csv_file.encode("UTF-8", 'Windows-1252').sub("\xEF\xBB\xBF", '')
       else
         begin
           xlsx = Roo::Spreadsheet.open(file.path, extension: :xlsx)


### PR DESCRIPTION
## What?
Fixing the error CSV::MalformedCSVError: Invalid byte sequence in UTF-8.

## Why?
This error is a flow breaking one causing the users unable to upload sheets to the platform

## How?
This error is occurring due to some characters encoded in window-1252 is being unrecognised.
Previously `force_encoding` was being done. Problem with that is `force_encode` only sets the encoding of the string but doesn't convert or changes the string itself.
I found 2 solutions to incorporate 
 1. Replace all the undefined and unrecognised characters to blank
 2. Convert to UTF-8 charset explicitly
Problem with point 1 is it would cause in loss of information. So I incorporated point 2. 
Converting encoding from windows-1252 to UTF-8 solves the problem