### PR TITLE
Change in private consultation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ config/environments/_add_gem_paths.js
 /config/credentials/production.key
 /config/database.yml
 /public/uploads/
+
+# Created and maintained by the Finder application in every folder in macOS
+.DS_Store

--- a/app/graphql/queries/consultation/profile.rb
+++ b/app/graphql/queries/consultation/profile.rb
@@ -9,8 +9,9 @@ module Queries
 
 	    def resolve(id:, response_token:)
 	    	consultation = ::Consultation.find(id)
-	    	raise CivisApi::Exceptions::Unauthorized if ((!context[:current_user].present? && response_token != consultation.response_token) && consultation.private_consultation?) 
-	    	return consultation
+	    	raise CivisApi::Exceptions::Unauthorized if ((!context[:current_user].present? && response_token != consultation.response_token))
+
+				return consultation
 	    end
 		end
 	end


### PR DESCRIPTION
## What?
Access for private consultation.

## Why?
The client is looking to change the flow of how end users access private consultations. 

The way they see the new flow working:
1. The user lands on the page
2. They can view the consultation details 
3. Fill in the form for consultation questions 
4. Submit the question after the login (If they have not already logged into the system)

## How?
From the `consultationProfile` query we have removed the check to raise the unauthorised access for private consultation.