### PR TITLE
Change invitation expiry condition based on response deadline

### DIFF
--- a/app/graphql/mutations/auth/accept_invite.rb
+++ b/app/graphql/mutations/auth/accept_invite.rb
@@ -9,7 +9,7 @@ module Mutations
         user = ::User.find_by_invitation_token(auth[:invitation_token], true)
         consultation = ::Consultation.find(auth[:consultation_id])
         raise CivisApi::Exceptions::FailedLogin, "Email not found" unless user
-        raise CivisApi::Exceptions::FailedLogin, "Invitation expired" if consultation.response_deadline.to_date <= Date.today
+        raise CivisApi::Exceptions::FailedLogin, "Invitation expired" if consultation.response_deadline.to_date <= Date.tomorrow
         user = ::User.accept_invitation!(auth.to_h.except!(:consultation_id))
         user.find_or_generate_api_key
         user.live_api_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :invitable, :database_authenticatable, :confirmable,
-         :recoverable, :rememberable, :validatable, :lockable, :timeoutable, :trackable, :omniauthable
+  devise :invitable, :database_authenticatable, :confirmable, :recoverable,
+         :rememberable, :validatable, :lockable, :timeoutable, :trackable, :omniauthable
 
 	belongs_to :city, class_name: "Location", foreign_key: "city_id", optional: true
 	has_many :api_keys, dependent: :destroy
@@ -103,7 +103,7 @@ class User < ApplicationRecord
   def send_email_verification
   	VerifyUserEmailJob.perform_later(self) unless confirmed_at
     if (!confirmed_at && referring_consultation_id)
-      VerifyUserEmailAfter8HoursJob.set(wait: 8.hours).perform_later(self.id, self.referring_consultation_id) 
+      VerifyUserEmailAfter8HoursJob.set(wait: 8.hours).perform_later(self.id, self.referring_consultation_id)
       VerifyUserEmailAfter72HoursJob.set(wait: 80.hours).perform_later(self.id)
       VerifyUserEmailAfter120HoursJob.set(wait: 200.hours).perform_later(self.id)
     end
@@ -174,12 +174,12 @@ class User < ApplicationRecord
         url = URI::HTTPS.build(Rails.application.config.host_url.merge!({path: "/users/edit_invite", query: "invitation_token=#{raw_token}"})).to_s
       end
       InviteOrganisationEmployeeJob.perform_later(user_record, url)
-    end 
+    end
   end
 
   def picture_url
     if self.profile_picture.present?
-      self.profile_picture_url  
+      self.profile_picture_url
     else
       "media/application/images/defalut-user.svg"
     end


### PR DESCRIPTION
## What?
Change invitation expiry condition based on response deadline

## Why?
Users have reported either the link expired or the attached error.