### PR TITLE
Bypass authentication for response submission

### DIFF
--- a/app/graphql/mutations/consultation_response/create.rb
+++ b/app/graphql/mutations/consultation_response/create.rb
@@ -7,7 +7,7 @@ module Mutations
 
       def resolve(consultation_response:)
         user = context[:current_user]
-        raise CivisApi::Exceptions::Unauthorized, I18n.t('consultation_response.unauthorized') unless user.present?
+        raise CivisApi::Exceptions::Unauthorized, I18n.t('consultation_response.unauthorized') unless user.present? || submission_allowed?(consultation_response.consultation_id)
 
         created_consultation_response = ::ConsultationResponse.new consultation_response.to_h
         created_consultation_response.user = user
@@ -21,6 +21,12 @@ module Mutations
         end
         created_consultation_response.save!
         return created_consultation_response
+      end
+
+      def submission_allowed?(consultation_id)
+        return true if (Rails.env.staging? && consultation_id.eql?(404)) || (Rails.env.staging? && consultation_id.eql?(707))
+
+        return false
       end
     end
   end

--- a/app/graphql/mutations/consultation_response/create.rb
+++ b/app/graphql/mutations/consultation_response/create.rb
@@ -6,14 +6,15 @@ module Mutations
       argument :consultation_response, Types::Inputs::ConsultationResponse::Create, required: true
 
       def resolve(consultation_response:)
+        user = context[:current_user]
         created_consultation_response = ::ConsultationResponse.new consultation_response.to_h
-        created_consultation_response.user = context[:current_user]
+        created_consultation_response.user = user
         @consultation = ::Consultation.find(consultation_response.consultation_id)
         active_response_round = @consultation.response_rounds.order(:created_at).last
         created_consultation_response.response_round = active_response_round
         if @consultation.private_consultation?
           raise GraphQL::ExecutionError, "Private response is enforced, response visibility can't be shared" if (@consultation.private_response? && created_consultation_response.visibility == "shared")
-          respondent = ::Respondent.find_by(user: context[:current_user], response_round: active_response_round)
+          respondent = ::Respondent.find_by(user: user, response_round: active_response_round)
           created_consultation_response.respondent_id = respondent.id if respondent
         end
         created_consultation_response.save!

--- a/app/graphql/mutations/consultation_response/create.rb
+++ b/app/graphql/mutations/consultation_response/create.rb
@@ -7,6 +7,8 @@ module Mutations
 
       def resolve(consultation_response:)
         user = context[:current_user]
+        raise CivisApi::Exceptions::Unauthorized, I18n.t('consultation_response.unauthorized') unless user.present?
+
         created_consultation_response = ::ConsultationResponse.new consultation_response.to_h
         created_consultation_response.user = user
         @consultation = ::Consultation.find(consultation_response.consultation_id)
@@ -19,10 +21,6 @@ module Mutations
         end
         created_consultation_response.save!
         return created_consultation_response
-      end
-
-      def self.accessible?(context)
-        context[:current_user].present?
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,3 +49,5 @@ en:
           local: "Local"
   auth:
     reset_pasword_token: "The reset password token is no longer valid, either expired after 7 days or has already been used. Please request a new one."
+  consultation_response:
+    unauthorized: "Login or signup to submit a response"


### PR DESCRIPTION
## What?
Bypass authentication for submission of consultation response for specific consultations. 

## Why?
The client has requested it. It's a consultation for disabled people and they want to remove any barrier to submit a response. They don't see a need for this in any other consultation in the near future.

## How?
On staging, [Digital India Bill](https://staging.civis.vote/consultations/404/read) consultation and on production [Charter of Demands: Of, By & For Persons with Disability](https://www.civis.vote/consultations/707/read) consultation