### PR TITLE
chore: add auto instruments monitoring in scout apm

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,8 +319,9 @@ GEM
     parallel (1.22.1)
     paranoia (2.6.0)
       activerecord (>= 5.1, < 7.1)
-    parser (3.1.2.0)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
+      racc
     pg (1.3.5)
     pg-aws_rds_iam (0.4.1)
       aws-sdk-rds (~> 1.0)
@@ -464,7 +465,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scout_apm (5.1.1)
+    scout_apm (5.3.8)
       parser
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)

--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -21,6 +21,7 @@ common: &defaults
   monitor: true
 
 production:
+  auto_instruments: true
   <<: *defaults
 
 development:
@@ -32,4 +33,5 @@ test:
   monitor: false
 
 staging:
+  auto_instruments: true
   <<: *defaults


### PR DESCRIPTION
## WHAT:
- add auto instruments monitoring in scout apm

## WHY:
- for better monitoring of application performance.

## HOW:
- added `auto_instruments` key to true in scout_apm config