### PR TITLE
fix: oauth redirect fail fix

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -1,28 +1,27 @@
 class OauthController < ApplicationController
-
-	def redirect_to_provider
-    if request.env["REQUEST_URI"].include?("signin_google")
-    	redirect_to "/users/auth/google_oauth2"
-    elsif request.env["REQUEST_URI"].include?("signin_linkedin")
-    	redirect_to "/users/auth/linkedin"
-    elsif request.env["REQUEST_URI"].include?("signin_facebook")
-    	redirect_to "/users/auth/facebook"
+	 def redirect_to_provider
+    if request.env['REQUEST_URI'].include?('signin_google')
+    	 redirect_to '/users/auth/google_oauth2'
+    elsif request.env['REQUEST_URI'].include?('signin_linkedin')
+    	 redirect_to '/users/auth/linkedin'
+    elsif request.env['REQUEST_URI'].include?('signin_facebook')
+    	 redirect_to '/users/auth/facebook'
     end
   end
 
   def callback
-    return unless request.env["omniauth.auth"]["info"]
-    user = User.find_by(email: request.env["omniauth.auth"]["info"][:email])
+    return unless request.env['omniauth.auth']['info']
+
+    user = User.find_by(email: request.env['omniauth.auth']['info'][:email])
     unless user
-      auth_info = request.env["omniauth.auth"]
+      auth_info = request.env['omniauth.auth']
       user = User.public_send("create_from_#{auth_info[:provider]}", auth_info[:info], auth_info[:uid])
     end
     user.api_keys.create unless user.api_keys.live.present?
-    redirect_to URI::HTTP.build(Rails.application.config.client_url.merge!({path: "/auth/success", query: "access_token=#{user.live_api_key.access_token}"})).to_s
+    redirect_to(URI::HTTP.build(Rails.application.config.client_url.merge!({ path: '/auth/success', query: "access_token=#{user.live_api_key.access_token}" })).to_s, allow_other_host: true)
   end
 
   def failure
-    redirect_to URI::HTTP.build(Rails.application.config.client_url.merge!({path: "/auth/failure"})).to_s
+    redirect_to(URI::HTTP.build(Rails.application.config.client_url.merge!({ path: '/auth/failure' })).to_s, allow_other_host: true)
   end
-
 end


### PR DESCRIPTION
## WHAT:
- fix for failing redirection on oauth

## WHY:
-  rails 7 doesn't allow other host redirection by default

## HOW:
- added `allow_other_host` key for allowing redirection to other hosts.