### PR TITLE
fix: expiry job fix

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -22,9 +22,9 @@ class Consultation < ApplicationRecord
 
   validates_presence_of :response_deadline
 
-  after_create :notify_admins
-  after_create :create_response_round
   after_commit :set_consultation_expiry_job, if: :saved_change_to_response_deadline?
+  after_commit :create_response_round, on: :create
+  after_commit :notify_admins, on: :create
 
   scope :status_filter, lambda { |status|
     return all unless status.present?


### PR DESCRIPTION
## WHAT: 
- expiry job fix

## WHY: 
- after_create hooks were running before `set_consultation_expiry_job` and that was updating consultation so `saved_change_to_response_deadline?` returning false