### PR TITLE
fix: remove skip_confirmation_notification! from user creation in sign up and add_fields_from_oauth methods

### DIFF
--- a/app/graphql/mutations/auth/sign_up.rb
+++ b/app/graphql/mutations/auth/sign_up.rb
@@ -7,7 +7,6 @@ module Mutations
 
       def resolve(auth:)
         user = ::User.new auth.to_h
-        user.skip_confirmation_notification!
         user.save!
         return user.live_api_key
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,7 +131,6 @@ class User < ApplicationRecord
   def self.add_fields_from_oauth(f_name, l_name, email, provider, uid, image_url)
     user = ::User.new first_name: f_name, last_name: l_name, email: email, provider: provider, uid: uid,
                       password: [*'a'..'z', *0..9, *'A'..'Z', *'!'..'?'].sample(11).join, confirmed_at: DateTime.now
-    user.skip_confirmation_notification!
     user.save!
     UserProfilePictureUploadJob.perform_later(user, image_url) if image_url
     user


### PR DESCRIPTION

fix for this error: https://errors.services.commutatus.com/apps/66863d425a3dd36ee6a4b806/problems/687a47c36773b9f219528fd1