### PR TITLE
Add nil check for response_round in user_answerS

### DIFF
--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -246,7 +246,8 @@ class ConsultationResponse < ApplicationRecord
 
   def user_answers
     answers_hash = {}
-
+    return answers_hash if response_round.nil?
+    
     response_round.questions.each do |question|
       answer_data = if answers.present?
                       answers.find { |ans| ans['question_id'].to_i == question.id }


### PR DESCRIPTION
Some consultation response has response_round_id as null
When we load the response tab - it crashes with undefined method 'questions' for nil.