### PR TITLE
Remove compressor

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,4 +118,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   Rails.application.routes.default_url_options = { host: ENV["HOST"], protocol: "https" }
   Rails.application.config.allowed_cors_origins = ['https://www.civis.vote']
+
+  config.assets.css_compressor = nil
+
 end


### PR DESCRIPTION
### What changes are done?
Disabled CSS compressor in all environments (development, staging, production)
Added config.assets.css_compressor = nil to environment configurations
Allows lexxy 0.9.10.beta to work without downgrading versions