### PR TITLE
CIV-63: Enabling CmPlatform Setting for civis

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,3 +1,3 @@
-CONSTANT_TYPES = %i[ministry_category segment clause_type].freeze
+CONSTANT_TYPES = %i[ministry_category segment clause_type setting_category].freeze
 
 DEFAULT_PER_PAGE = 20

--- a/config/initializers/zcm_admin.rb
+++ b/config/initializers/zcm_admin.rb
@@ -5,7 +5,7 @@ Rails.application.reloader.to_prepare do
     # config.authorized_roles = [:super_admin?]
     config.included_models = [Theme, CmRole, CmPermission, User, Wordindex, Profanity, CaseStudy,
                               ConsultationResponse, Department, Organisation, Consultation, GlossaryWordConsultationMapping,
-                              ResponseRound, Question, FileImport, FileExport, Respondent, TeamMember, Clause, Constant]
+                              ResponseRound, Question, FileImport, FileExport, Respondent, TeamMember, Clause, Constant, CmPlatformSetting]
 
     config.project_name = Rails.configuration.x.project_settings.name
     config.enable_tracking = true
@@ -58,6 +58,10 @@ Rails.application.reloader.to_prepare do
       {
         display_name: 'Constants',
         path: :cm_index_constant_path
+      },
+      {
+        display_name: 'Platform Settings',
+        path: :cm_index_cm_platform_setting_path
       }
     ]
   end


### PR DESCRIPTION
### What does this change do? 
Integrates the CmPlatformSetting component from the cm-admin gem into the Civis admin panel, enabling key-value platform configuration management via the admin UI.

### Why is this change needed?
Platform-level settings (project name, logo, email addresses, etc.) should be manageable by admins .

### How were the changes done?
- Added setting_category to CONSTANT_TYPES in config/initializers/constants.rb — enables the Constant.setting_category scope used by CmPlatformSetting for grouping settings, and auto-generates the required select_options_for_setting_category helper via the existing loop in custom_helper.rb
- Registered CmPlatformSetting in config.included_models and added a "Platform Settings" entry to config.sidebar in config/initializers/zcm_admin.rb — makes the model accessible through cm-admin routes and visible in the admin navigation

### How was testing done? 
 Tested on local server "Platform Settings" appears in the admin sidebar
/cm_admin/cm_platform_settings loads without errors
Running CmPlatformSetting.add_cm_default_settings in console successfully seeds default settings with correct categories
