### PR TITLE
(chore) Add windsurf configuration files with coding standards and rules

### DIFF
--- a/.windsurf/rules/.cm-manifest.json
+++ b/.windsurf/rules/.cm-manifest.json
@@ -1,0 +1,11 @@
+{
+  "commit": "00bb660f26848543bd10e2a1c92ef126d333a9ca",
+  "platform": "rails",
+  "managed_rules": [
+    "active-record.md",
+    "cm-admin.md",
+    "commit-message.md",
+    "prettier.md",
+    "rubocop.md"
+  ]
+}

--- a/.windsurf/rules/active-record.md
+++ b/.windsurf/rules/active-record.md
@@ -1,0 +1,42 @@
+---
+trigger: glob
+globs: app/models/**/*
+---
+
+# Validations
+
+For each active record model make sure to add sensible validations
+1. For date of birth fields make sure to prevent future dates
+2. For email fields normalize email to downcase, ensure that email is unique, and validate the email format using the EmailValidator. normalize email like this `normalizes :email, with: ->(email) { email&.downcase }` and validate like this `validates :email, email: true, allow_blank: true`
+3. If there are fields for start and end date on a model; then add a validation that the start date cannot be greater than the end date.
+
+# Callbacks
+
+For each active record model make sure to add sensible callbacks
+1. For automatically capturing the user who created or last updated each record, include the Trackable concern
+```ruby
+include Trackable
+
+This will automatically add the association and the callbacks.
+```
+
+2. Formatted ID generation
+```ruby
+after_create :set_formatted_id
+
+def set_formatted_id
+  update(formatted_id: "RE - #{id}")   # ReimbursementRequest
+end
+```
+
+3. Record timestamp and user ID whenever a status field changes using store_accessor for accessors
+```ruby
+store_accessor :status_change_log, *statuses.keys.flat_map { |status| ["#{status}_at", "#{status}_by"] }
+
+after_commit :update_status_change_log, if: -> { saved_change_to_status? }
+
+def update_status_change_log
+  update!("#{status}_at" => Time.current, "#{status}_by" => Current.user&.id)
+end
+```
+

--- a/.windsurf/rules/cm-admin.md
+++ b/.windsurf/rules/cm-admin.md
@@ -1,0 +1,22 @@
+---
+trigger: glob
+globs: app/models/concerns/cm_admin/**/*
+---
+
+# CM Admin DSL Guidelines
+
+When working with files in this directory, always reference the official documentation for the latest DSL methods and patterns.
+
+## Documentation Reference
+
+Before making changes, read the documentation only at:
+https://docs.cm-admin.commutatus.com/docs
+
+<instructions>
+1. Before making changes, search the cm-admin documentation site for relevant DSL methods
+2. Browse and navigate the docs site to find the appropriate page for the current task
+3. Follow the patterns and methods described in the official docs
+4. When unsure about any DSL syntax, always search the docs first
+5. When creating new migrations ensure that the email field is always in citext
+6. Use the appropriate field type for the field, email fields should have input_type: :email, for phone number fields use input_type: :phone
+</instructions>

--- a/.windsurf/rules/commit-message.md
+++ b/.windsurf/rules/commit-message.md
@@ -1,0 +1,23 @@
+---
+trigger: always_on
+---
+
+# Commit Message Format
+
+When generating commit messages, follow the Conventional Commits specification:
+use the @web to read conventional commits guidelines (https://www.conventionalcommits.org/en/v1.0.0/#summary)
+
+- Format: `type(scope): single line description`
+- Never add ``` block for commit message
+- Types: feat, fix, refactor, docs, style, test, chore, perf, ci, build
+- Keep the main message on a single line, clear and concise
+- Add extra details as a markdown bullet list below if needed
+- Each bullet point should include the reason why that change was made
+- Where applicable, provide insight into the impact of not including the change
+
+Example:
+
+feat(auth): add OAuth2 login support
+
+- Added Google OAuth provider — enables single-click login for Google Workspace users
+- Updated user session handling — previous implementation lost sessions on token refresh

--- a/.windsurf/rules/prettier.md
+++ b/.windsurf/rules/prettier.md
@@ -1,0 +1,16 @@
+---
+trigger: glob
+globs: **/*.js, **/*.jsx, **/*.ts, **/*.tsx, **/*.css, **/*.scss, **/*.json
+---
+
+# JavaScript & CSS Code Style
+
+## Prettier Formatting
+
+Always format code using Prettier before completing changes.
+
+<instructions>
+1. After making changes, run `npx prettier --write` on modified files
+2. Follow the project's `.prettierrc` configuration if present
+3. Never disable Prettier rules without explicit user approval
+</instructions>

--- a/.windsurf/rules/rubocop.md
+++ b/.windsurf/rules/rubocop.md
@@ -1,0 +1,17 @@
+---
+trigger: glob
+globs: **/*.rb, **/*.rake, Rakefile, Gemfile
+---
+
+# Ruby Code Style
+
+## Rubocop Formatting
+
+Always format Ruby code using Rubocop before completing changes.
+
+<instructions>
+1. After making changes, run `bundle exec rubocop -a` on modified files
+2. If auto-correct fails, review the offenses and fix manually
+3. Follow the project's `.rubocop.yml` configuration
+4. Never disable Rubocop rules without explicit user approval
+</instructions>


### PR DESCRIPTION
### What does this change do?
- Adds new windsurf rules for centralised configuration management.

### How were the changes done?
Ran below commands-
- brew tap commutatus/tools https://github.com/commutatus/homebrew-tools
- brew install cm-tools
- cm-tools windsurf-sync -p rails
