### PR TITLE
[Staging] Fix: Removed the beta cm-admin version from staging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ gem 'jwt'
 gem 'ruby-openai'
 
 gem 'apollo_upload_server'
-gem 'cm-admin', '6.2.20.beta1', source: 'https://cm-gems.commutatus.com'
+gem 'cm-admin', source: 'https://cm-gems.commutatus.com'
 gem 'cm-geocoder'
 gem 'positioning'
 gem 'stimulus-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -740,7 +740,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
-  cm-admin (= 6.2.20.beta1)!
+  cm-admin!
   cm-geocoder
   cocoon
   database_cleaner


### PR DESCRIPTION
### What Changes were done?
- Staging deployment failed , In Gemfile beta version was implemented , and the CIV-69 changes only included the updated Gemfile.lock , so need to apply a fix with correct Gemfile.