### PR TITLE
[Staging] Removing sassc-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,6 @@ gem 'http'
 gem 'psych', '< 4'
 
 gem 'importmap-rails'
-gem 'sassc-rails'
 gem 'turbo-rails'
 
 gem 'airbrake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -618,14 +618,6 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.4.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     scout_apm (5.6.4)
       parser
     securerandom (0.4.1)
@@ -776,7 +768,6 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   ruby-progressbar
-  sassc-rails
   scout_apm
   selenium-webdriver
   sidekiq


### PR DESCRIPTION
Removing sassc-rails gem for staging deployment fail fix to implement css bundling.