### PR TITLE
chore: add health endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
   add_flash_types :flash_info, :flash_success_info
   include ActiveStorage::SetCurrent
+
+  def health
+    User.exists?
+    render json: { message: 'Health Check OK' }, status: :ok
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
 
   root 'cm_admin/static#index'
 
+  get :health, to: 'application#health'
+
   get 'signin_google', to: 'oauth#redirect_to_provider'
   get 'signin_linkedin', to: 'oauth#redirect_to_provider'
   get 'signin_facebook', to: 'oauth#redirect_to_provider'


### PR DESCRIPTION
Bridge Ticket: [CIV-67](https://bridge.commutatus.com/cm_admin/tasks/CIV-67)

## What does this change do?

Adds a health check endpoint (`/health`) to the Civis API application that returns a JSON response with HTTP 200 status.

## Why is this change needed?

The Bridge deployment platform requires a health check endpoint to monitor application availability. Without this endpoint, the deployment health checks cannot be configured.

## How were the changes done?

- Added `health` method to `ApplicationController` that checks database connectivity via `User.exists?`
- Added route `get :health, to: 'application#health'` to `config/routes.rb`
- Follows the established pattern used in other Commtatus projects (dre-api, picklout-be)

## How was testing done?

- Tested locally by starting the Rails server and hitting `http://localhost:3000/health`
- Verified the endpoint returns HTTP 200 with `{"message":"Health Check OK"}`
- Confirmed database connectivity check works via `User.exists?`

## AI Code Review Summary

No issues found. ✅

## Anything Else?

The endpoint is suitable for deployment monitoring tools and has no security concerns as it only returns a generic success message.