### PR TITLE
feat(mailer): add formatted OTP to email template

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -466,13 +466,16 @@ class UserMailer < ApplicationMailer
     otp = user.otp_requests.active.last&.otp
     return unless otp
 
+    formatted_otp = otp.to_s[0, 3] + ' ' + otp.to_s[3, 3]
+
     @@postmark_client.deliver_with_template(
       from: @@from_email,
       to: user.email,
       template_alias: 'otp-verification',
       template_model: template_model_base.merge!({ name: user.first_name,
         product_url: Rails.application.config.client_url[:host],
-        otp: 
+        otp: otp,
+        formatted_otp: formatted_otp
       })
     )
   end


### PR DESCRIPTION
Bridge Ticket: [CIV-54](https://bridge.commutatus.com/cm_admin/tasks/CIV-54)

## What does this change do?

Adds a formatted OTP variable to the email template that splits the 6-digit code into two groups of 3 digits with a space for better readability (e.g., "123 456").

## Why is this change needed?

Improves OTP readability in emails for users by displaying the code in a more visually digestible format.

## How were the changes done?

- Added string slicing logic to format the OTP: `otp.to_s[0, 3] + ' ' + otp.to_s[3, 3]`
- Passed both the raw `otp` and formatted `formatted_otp` to the Postmark template model
- This allows the template to use either format depending on design needs

## How was testing done?

No test files were modified in this change. Manual testing of the email template is recommended to verify the formatted OTP displays correctly.

## AI Code Review Summary

No issues found. ✅

The change adds a formatted OTP (splitting the 6-digit code into two groups of 3 digits with a space) for better readability in the email template. The implementation is correct:

- OTP is generated as a 6-digit number (`rand(100_000..999_999)`)
- String slicing `otp.to_s[0, 3] + ' ' + otp.to_s[3, 3]` correctly formats it as "XXX XXX"
- Both raw and formatted OTP are passed to the template for flexibility

## Screenshot
<img width="1361" height="687" alt="Screenshot 2026-06-05 at 3 09 34 PM" src="https://github.com/user-attachments/assets/b1e94cb3-79d1-44ff-8640-2a3e7c4337db" />
