### PR TITLE
fix(mail): pass otp halves to fix clipboard copy issue

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -466,8 +466,6 @@ class UserMailer < ApplicationMailer
     otp = user.otp_requests.active.last&.otp
     return unless otp
 
-    formatted_otp = otp.to_s[0, 3] + ' ' + otp.to_s[3, 3]
-
     @@postmark_client.deliver_with_template(
       from: @@from_email,
       to: user.email,
@@ -475,7 +473,8 @@ class UserMailer < ApplicationMailer
       template_model: template_model_base.merge!({ name: user.first_name,
         product_url: Rails.application.config.client_url[:host],
         otp: otp,
-        formatted_otp: formatted_otp
+        otp_first: otp.to_s[0, 3],
+        otp_second: otp.to_s[3, 3]
       })
     )
   end


### PR DESCRIPTION
## Summary

Fixes an issue where copying the OTP from the email included a space character, making the pasted OTP invalid.

## Changes

- Modified `UserMailer#send_otp` to pass `otp_first` and `otp_second` separately to the Postmark template
- Removed `formatted_otp` which included a literal space character
- Postmark template will use CSS margin for visual spacing (e.g., "161 834") while keeping clipboard copy clean (e.g., "161834")

## Context

The OTP email template displays the 6-digit code with visual spacing for better readability. Previously, this was done by including a literal space character in the `formatted_otp` variable. When users copied the OTP from the email, the space was included, causing validation failures.

The solution passes the two halves of the OTP separately and uses CSS margin in the template for visual spacing, ensuring clipboard copy returns clean digits only.

## Testing

Tested locally by:
1. Generating an OTP request
2. Verifying the email displays with visual spacing
3. Copying the OTP from the email and confirming it pastes without spaces