### PR TITLE
[Staging] CIV-85 - Add "Area of Impact" Field to Consultation Admin

### DIFF
--- a/app/graphql/queries/consultation/list.rb
+++ b/app/graphql/queries/consultation/list.rb
@@ -10,12 +10,14 @@ module Queries
       argument :sort, Types::Enums::ConsultationSorts, required: false, default_value: nil
       argument :sort_direction, Types::Enums::SortDirections, required: false, default_value: nil
       argument :status_filter, String, required: false, default_value: nil
+      argument :area_of_impact_filter, [Int], required: false, default_value: nil
 
       type Types::Objects::Consultation::List, null: true
 
-      def resolve(featured_filter:, status_filter:, department_filter:, theme_filter:, per_page:, page:, sort:, sort_direction:)
+      def resolve(featured_filter:, status_filter:, department_filter:, theme_filter:, area_of_impact_filter:, per_page:, page:, sort:, sort_direction:)
         ::Consultation.includes(:anonymous_responses).public_consultation.featured_filter(featured_filter)
                       .status_filter(status_filter).department_filter(department_filter).theme_filter(theme_filter)
+                      .area_of_impact_filter(area_of_impact_filter)
                       .sort_records(sort, sort_direction).list(per_page, page)
       end
     end

--- a/app/graphql/types/objects/consultation/base.rb
+++ b/app/graphql/types/objects/consultation/base.rb
@@ -60,6 +60,7 @@ module Types
         field :summary_hindi, String, nil, null: true
         field :page, String, nil, null: true
         field :consultation_partner_responses, [Types::Objects::ConsultationPartnerResponse::Base], nil, null: true
+        field :area_of_impacts, [Types::Objects::Constant], nil, null: true
         field :has_user_filled_response_in_current_response_round, Boolean, null: true
 
         def has_user_filled_response_in_current_response_round

--- a/app/models/concerns/cm_admin/consultation.rb
+++ b/app/models/concerns/cm_admin/consultation.rb
@@ -7,7 +7,7 @@ module CmAdmin
     included do
       cm_admin do
         actions only: []
-        permit_additional_fields [segment_ids: []]
+        permit_additional_fields [segment_ids: [], area_of_impact_ids: []]
         set_icon 'fas fa-clipboard-list'
         set_policy_scopes [{ scope_name: 'organisation_only', display_name: 'Organisation Only' }]
         sortable_columns [
@@ -26,6 +26,8 @@ module CmAdmin
           filter :theme_id, :multi_select, helper_method: :select_options_for_theme
           filter :review_type, :multi_select
           filter :created_by_id, :multi_select, helper_method: :select_options_for_admin_panel_user
+          filter :area_of_impact_ids, :multi_select, helper_method: :select_options_for_area_of_impact,
+                 filter_with: :area_of_impact_filter, display_name: 'Area of Impact'
 
           custom_action name: 'publish', route_type: 'member', verb: 'patch', path: ':id/publish',
                         icon_name: 'fa-solid fa-check', display_type: :button,
@@ -189,6 +191,7 @@ module CmAdmin
                                                       display_if: ->(_) { !Current.user&.role?('organisation_employee') }
               field :show_satisfaction_rating, field_type: :boolean, label: 'Show Satisfaction Rating Question?'
               field :question_flow, field_type: :enum
+              field :area_of_impact_names, label: 'Area of Impact'
               field :segment_names, label: 'Segments'
               field :created_by_full_name, label: 'Created By'
             end
@@ -264,6 +267,8 @@ module CmAdmin
             form_field :question_flow, input_type: :single_select
             form_field :segment_ids, input_type: :multi_select, helper_method: :select_options_for_segment,
                                      display_if: ->(_) { Current.user&.role?('super_admin') }, label: 'Segments'
+            form_field :area_of_impact_ids, input_type: :multi_select,
+                                            helper_method: :select_options_for_area_of_impact, label: 'Area of Impact'
           end
           cm_section 'Summary' do
             form_field :english_summary, input_type: :rich_text
@@ -297,6 +302,8 @@ module CmAdmin
             form_field :question_flow, input_type: :single_select
             form_field :segment_ids, input_type: :multi_select, helper_method: :select_options_for_segment,
                                      display_if: ->(_) { Current.user&.role?('super_admin') }, label: 'Segments'
+            form_field :area_of_impact_ids, input_type: :multi_select,
+                                            helper_method: :select_options_for_area_of_impact, label: 'Area of Impact'
           end
           cm_section 'Summary' do
             form_field :english_summary, input_type: :rich_text

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -54,6 +54,7 @@ class Consultation < ApplicationRecord
   has_many :clauses, dependent: :destroy
   has_many :constant_maps, as: :mappable, dependent: :destroy
   has_many :segments, -> { segment }, through: :constant_maps, source: :constant
+  has_many :area_of_impacts, -> { area_of_impact }, through: :constant_maps, source: :constant
 
   validates_presence_of :response_deadline, :question_flow
 
@@ -83,6 +84,12 @@ class Consultation < ApplicationRecord
     return all unless theme_id.present?
 
     where(theme_id: theme_id)
+  }
+
+  scope :area_of_impact_filter, lambda { |area_of_impact_ids|
+    return all unless area_of_impact_ids.present?
+
+    joins(:constant_maps).where(constant_maps: { constant_id: area_of_impact_ids }).distinct
   }
 
   scope :featured_filter, lambda { |featured|
@@ -119,6 +126,10 @@ class Consultation < ApplicationRecord
 
   def segment_names
     segments.map(&:name).join(", ")
+  end
+
+  def area_of_impact_names
+    area_of_impacts.map(&:name).join(", ")
   end
 
   def publish

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,3 +1,3 @@
-CONSTANT_TYPES = %i[ministry_category segment clause_type setting_category].freeze
+CONSTANT_TYPES = %i[ministry_category segment clause_type setting_category area_of_impact].freeze
 
 DEFAULT_PER_PAGE = 20

--- a/db/migrate/20260626062600_seed_area_of_impact_constants.rb
+++ b/db/migrate/20260626062600_seed_area_of_impact_constants.rb
@@ -1,0 +1,43 @@
+class SeedAreaOfImpactConstants < ActiveRecord::Migration[8.1]
+  AREA_OF_IMPACT_VALUES = [
+    'National',
+    'Andhra Pradesh',
+    'Arunachal Pradesh',
+    'Assam',
+    'Bihar',
+    'Chhattisgarh',
+    'Goa',
+    'Gujarat',
+    'Haryana',
+    'Himachal Pradesh',
+    'Jharkhand',
+    'Karnataka',
+    'Kerala',
+    'Madhya Pradesh',
+    'Maharashtra',
+    'Manipur',
+    'Meghalaya',
+    'Mizoram',
+    'Nagaland',
+    'Odisha',
+    'Punjab',
+    'Rajasthan',
+    'Sikkim',
+    'Tamil Nadu',
+    'Telangana',
+    'Tripura',
+    'Uttar Pradesh',
+    'Uttarakhand',
+    'West Bengal'
+  ].freeze
+
+  def up
+    AREA_OF_IMPACT_VALUES.each do |name|
+      Constant.find_or_create_by!(name: name, constant_type: :area_of_impact)
+    end
+  end
+
+  def down
+    Constant.where(constant_type: :area_of_impact).destroy_all
+  end
+end


### PR DESCRIPTION
Add a new area_of_impact field to the consultation model in CM Admin, allowing consultations to be tagged by nation or specific state.

