### PR TITLE
fix(admin): fix conditional question dropdown initialization

### DIFF
--- a/app/assets/javascripts/cm_admin/custom.js
+++ b/app/assets/javascripts/cm_admin/custom.js
@@ -22,26 +22,24 @@ document.addEventListener("turbo:load", function () {
       response_round_id: responseRoundId ?? ""
     };
 
-    const element = document.querySelector(
+    const elements = document.querySelectorAll(
       '[data-field-name="conditional_question_id"]'
     );
 
-    if (!element) return;
+    if (!elements.length) return;
 
-    window.cmSelect(element, {
-      url: url,
-      queryData: queryData
+    elements.forEach(function (el) {
+      window.cmSelect(el, {
+        url: url,
+        queryData: queryData
+      });
     });
 
   }
 
-  $(document).on(
-    "click",
-    '.nested-table-footer [data-association="sub_question"]',
-    function () {
-      updateConditionalQuestionOptions();
-    }
-  );
+  document.addEventListener('cm-nested-forms:added', function() {
+    updateConditionalQuestionOptions();
+  });
   updateConditionalQuestionOptions();
 
   $(document).on("change", '[data-field-name="question_type"]', function () {

--- a/app/helpers/cm_admin/custom_helper.rb
+++ b/app/helpers/cm_admin/custom_helper.rb
@@ -59,7 +59,8 @@ module CmAdmin
     end
 
     def selected_conditional_option(record, _)
-      [[record&.conditional_question&.question_text, record&.conditional_question&.id]]
+      return [] if record&.conditional_question.blank?
+      [[record.conditional_question.question_text, record.conditional_question.id]]
     end
 
     def select_options_for_boolean(_ = nil, _ = nil)

--- a/app/models/concerns/cm_admin/question.rb
+++ b/app/models/concerns/cm_admin/question.rb
@@ -32,7 +32,7 @@ module CmAdmin
             @questions = ::Question.main_questions.where(response_round_id:).search_filter(params[:search])
             @questions = @questions.where.not(id: params[:question_id]) if params[:question_id].present?
             {
-              "results": @questions.map { |question| { "id": question.id, "text": question.question_text } },
+              "results": @questions.map { |question| { "id": question.id, "title": question.question_text } },
               "pagination": { "more": false }
             }
           end


### PR DESCRIPTION
Bridge Ticket: [CIV-87](https://bridge.commutatus.com/cm_admin/tasks/CIV-87)

## What does this change do?

Fixes the conditional question dropdown bug in the admin interface where dropdowns were not populating for sub_question rows beyond the first row.

## Why is this change needed?

Production bug where:
- Only the first sub_question row's conditional question dropdown would load options
- Subsequent rows showed empty dropdowns
- "undefined" appeared as an option when no conditional question was selected

## How were the changes done?

- Changed `querySelector` to `querySelectorAll` with `forEach` loop to initialize all dropdown rows on page load
- Replaced jQuery click handler with native `addEventListener` for `cm-nested-forms:added` event to initialize new row dropdowns immediately after DOM insertion
- Changed JSON response field from `"text"` to `"title"` to match Tom Select's expected label field
- Added early return when `conditional_question` is blank to prevent "undefined" appearing in dropdown

## How was testing done?

Manual testing:
- Verified that existing sub_question rows load dropdown options correctly
- Verified that newly added sub_question rows load dropdown options immediately
- Verified that "undefined" no longer appears as an option when no conditional question is selected

## AI Code Review Summary

No issues found. ✅

### Code Changes Reviewed

The following files were modified to fix the conditional question dropdown bug:

1. **`app/assets/javascripts/cm_admin/custom.js`**
   - Changed `querySelector` to `querySelectorAll` with `forEach` loop to initialize all dropdown rows
   - Replaced jQuery click handler with native `addEventListener` for `cm-nested-forms:added` event
   - ✅ Logic is correct, follows cm-admin patterns

2. **`app/helpers/cm_admin/custom_helper.rb`**
   - Added early return when `conditional_question` is blank to prevent "undefined" in dropdown
   - ✅ Logic is correct, handles edge case properly

3. **`app/models/concerns/cm_admin/question.rb`**
   - Changed JSON response field from `"text"` to `"title"` to match Tom Select's expected label field
   - ✅ Logic is correct, fixes the field name mismatch

<!-- review-and-fix: 72620a0181229e46e2b269870eb19fa9b5ae0e76 -->