### PR TITLE
fix(clause): prevent duplicate clauses and empty clause_type on re-extraction

### DIFF
--- a/app/schemas/consultation_clauses_response_schema.rb
+++ b/app/schemas/consultation_clauses_response_schema.rb
@@ -4,7 +4,7 @@ class ConsultationClausesResponseSchema < RubyLLM::Schema
       string :clause_id, description: "Unique identifier for the clause"
       string :clause_title, description: "Title of the clause"
       string :what_is_proposed, description: "What is being proposed in this clause"
-      string :clause_type, description: "Type of the clause (e.g., Policy, Regulation, Amendment)"
+      string :clause_type, description: "Type of the clause", enum: Constant.where(constant_type: :clause_type).pluck(:name)
       string :stakeholder_impact, description: "Impact on stakeholders"
       array :keywords, of: :string, description: "Keywords associated with the clause"
     end

--- a/app/services/clause_extraction_service.rb
+++ b/app/services/clause_extraction_service.rb
@@ -89,9 +89,11 @@ class ClauseExtractionService
     created_clauses = []
 
     ActiveRecord::Base.transaction do
+      consultation.clauses.destroy_all
+
       clauses_array.each_with_index do |clause_data, index|
         clause = build_clause(clause_data, index + 1)
-        
+
         if clause.valid?
           clause.save!
           created_clauses << clause


### PR DESCRIPTION
Bridge Ticket: [Civ-114](https://bridge.commutatus.com/cm_admin/tasks/Civ-114)

## What does this change do?

- Prevent duplicate clauses on PDF re-extraction by destroying existing clauses before re-extraction
- Add enum validation for `clause_type` to prevent empty/invalid values

## Why is this change needed?

Re-extracting the same PDF was creating duplicate clauses, causing clause counts to double (e.g., 18 → 36, 19 → 40).

## How were the changes done?

- Added `consultation.clauses.destroy_all` in `ClauseExtractionService` before creating new clauses
- Updated `ConsultationClausesResponseSchema` to validate `clause_type` against existing `Constant` records

## How was testing done?

Manual verification: re-extracted PDFs and confirmed clause counts remain stable across multiple extractions.

<!-- review-and-fix: 2da57aa609334d585b4a9b465c1b3f5376452bf9 -->