### PR TITLE
feat(consultation): add AI-generated response summaries in multiple languages

### DIFF
--- a/app/graphql/types/objects/consultation/base.rb
+++ b/app/graphql/types/objects/consultation/base.rb
@@ -57,7 +57,11 @@ module Types
         field :odia_summary, String, nil, null: true
         field :marathi_summary, String, nil, null: true
         field :kannada_summary, String, nil, null: true
-        field :summary_hindi, String, nil, null: true
+        field :english_response_summary, String, nil, null: true
+        field :hindi_response_summary, String, nil, null: true
+        field :odia_response_summary, String, nil, null: true
+        field :marathi_response_summary, String, nil, null: true
+        field :kannada_response_summary, String, nil, null: true
         field :page, String, nil, null: true
         field :consultation_partner_responses, [Types::Objects::ConsultationPartnerResponse::Base], nil, null: true
         field :area_of_impacts, [Types::Objects::Constant], nil, null: true
@@ -84,10 +88,6 @@ module Types
         end
 
         def page
-          nil
-        end
-
-        def summary_hindi
           nil
         end
 
@@ -135,6 +135,26 @@ module Types
           return unless object.kannada_summary.to_s.present?
 
           object.kannada_summary_rich_text
+        end
+
+        def english_response_summary
+          object.english_response_summary.to_s
+        end
+
+        def hindi_response_summary
+          object.hindi_response_summary.to_s
+        end
+
+        def odia_response_summary
+          object.odia_response_summary.to_s
+        end
+
+        def marathi_response_summary
+          object.marathi_response_summary.to_s
+        end
+
+        def kannada_response_summary
+          object.kannada_response_summary.to_s
         end
 
         def shared_responses(sort:, sort_direction:)

--- a/app/jobs/consultation_summary_job.rb
+++ b/app/jobs/consultation_summary_job.rb
@@ -1,0 +1,30 @@
+class ConsultationSummaryJob < ApplicationJob
+  queue_as :default
+
+  def perform(consultation_id)
+    consultation = Consultation.find_by(id: consultation_id)
+
+    unless consultation
+      Rails.logger.error("ConsultationSummaryJob: Consultation not found with ID #{consultation_id}")
+      return
+    end
+
+    Rails.logger.info("ConsultationSummaryJob: Starting AI summary generation for Consultation #{consultation.id}")
+
+    service = ConsultationSummaryService.new(consultation)
+    result = service.call
+
+    if result[:success]
+      Rails.logger.info("ConsultationSummaryJob: Successfully generated AI summary for Consultation #{consultation.id}")
+    else
+      Rails.logger.error("ConsultationSummaryJob: Failed to generate AI summary for Consultation #{consultation.id}: #{result[:message]}")
+    end
+
+    result
+  rescue StandardError => e
+    Rails.logger.error("ConsultationSummaryJob: Unexpected error for Consultation #{consultation_id}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+
+    { success: false, message: "Job failed: #{e.message}", errors: [e.message] }
+  end
+end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -39,6 +39,12 @@ class Consultation < ApplicationRecord
   has_rich_text :marathi_summary
   has_rich_text :kannada_summary
 
+  has_rich_text :english_response_summary
+  has_rich_text :hindi_response_summary
+  has_rich_text :marathi_response_summary
+  has_rich_text :odia_response_summary
+  has_rich_text :kannada_response_summary
+
   has_one_attached :consultation_logo
   has_one_attached :consultation_pdf
 
@@ -157,6 +163,7 @@ class Consultation < ApplicationRecord
     expired!
     return unless responses.acceptable.size.positive?
 
+    ConsultationSummaryJob.perform_later(id)
     feedback_report_email(consultation_feedback_email, officer_name, officer_designation) if consultation_feedback_email
     if consultation?
       if department.primary_contact.present?

--- a/app/services/consultation_summary_service.rb
+++ b/app/services/consultation_summary_service.rb
@@ -1,0 +1,137 @@
+class ConsultationSummaryService
+  SUMMARY_MODEL = 'openai/gpt-5.6-luna'.freeze
+  PROMPT_FILE = Rails.root.join('config/prompts/consultation_ai_summary.prompt').freeze
+
+  LANGUAGES = {
+    'English' => :english_response_summary,
+    'Hindi' => :hindi_response_summary,
+    'Marathi' => :marathi_response_summary,
+    'Odia' => :odia_response_summary,
+    'Kannada' => :kannada_response_summary
+  }.freeze
+
+  attr_reader :consultation, :errors
+
+  def initialize(consultation)
+    @consultation = consultation
+    @errors = []
+  end
+
+  def call
+    return failure_result("Consultation not found") unless consultation
+    return failure_result("Consultation has no acceptable responses") unless consultation.responses.acceptable.exists?
+
+    responses_data = collect_question_responses
+    return failure_result("No question responses found to summarize") if responses_data.blank?
+
+    summaries = {}
+
+    LANGUAGES.each do |language, attribute|
+      Rails.logger.info("ConsultationSummaryService: Generating #{language} summary for Consultation #{consultation.id}")
+      prompt = build_prompt(responses_data, language)
+      result = generate_summary(prompt)
+
+      if result.present?
+        consultation.send("#{attribute}=", result)
+        summaries[language] = result
+      else
+        Rails.logger.warn("ConsultationSummaryService: Empty summary for #{language} on Consultation #{consultation.id}")
+      end
+    end
+
+    return failure_result("AI summary generation returned empty content for all languages") if summaries.blank?
+
+    consultation.update!(response_summary: summaries)
+    success_result(summaries)
+  rescue StandardError => e
+    Rails.logger.error("ConsultationSummaryService failed for Consultation #{consultation.id}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    failure_result("Summary generation failed: #{e.message}")
+  end
+
+  private
+
+  def collect_question_responses
+    responses = consultation.responses.acceptable.includes(:response_round, :user)
+    formatted = []
+
+    responses.each_with_index do |response, index|
+      response_entry = build_response_entry(response, index + 1)
+      formatted << response_entry if response_entry.present?
+    end
+
+    formatted
+  end
+
+  def build_response_entry(response, index)
+    if response.response_round&.questions&.present?
+      build_question_answer_entry(response, index)
+    elsif response.response_text.present?
+      build_generic_response_entry(response, index)
+    end
+  end
+
+  def build_question_answer_entry(response, index)
+    answers_hash = response.user_answers
+    return nil if answers_hash.blank? || answers_hash.values.all?(&:blank?)
+
+    qa_pairs = answers_hash.map do |question_text, answer_text|
+      next if answer_text.blank?
+
+      "    Q: #{question_text}\n    A: #{answer_text}"
+    end.compact
+
+    return nil if qa_pairs.blank?
+
+    <<~ENTRY
+      Response ##{index}:
+      #{qa_pairs.join("\n")}
+    ENTRY
+  end
+
+  def build_generic_response_entry(response, index)
+    text = response.response_text.to_plain_text
+    return nil if text.blank?
+
+    <<~ENTRY
+      Response ##{index}:
+      #{text}
+    ENTRY
+  end
+
+  def build_prompt(responses_data, language)
+    File.read(PROMPT_FILE).strip
+        .gsub('{{CONSULTATION_TITLE}}', consultation.title.to_s)
+        .gsub('{{CONSULTATION_TYPE}}', consultation.review_type.to_s)
+        .gsub('{{DEPARTMENT_NAME}}', consultation.department_name.to_s)
+        .gsub('{{RESPONSES_DATA}}', responses_data.join("\n\n"))
+        .gsub('{{OUTPUT_LANGUAGE}}', language)
+  end
+
+  def generate_summary(prompt)
+    chat = RubyLLM.chat(
+      model: SUMMARY_MODEL,
+      provider: :openrouter,
+      assume_model_exists: true
+    )
+    chat.ask(prompt)&.content
+  end
+
+  def success_result(summaries)
+    {
+      success: true,
+      summaries: summaries,
+      message: "AI summaries generated successfully for #{summaries.keys.join(', ')}"
+    }
+  end
+
+  def failure_result(message)
+    @errors << message
+    {
+      success: false,
+      summary: nil,
+      message: message,
+      errors: @errors
+    }
+  end
+end

--- a/config/prompts/consultation_ai_summary.prompt
+++ b/config/prompts/consultation_ai_summary.prompt
@@ -1,0 +1,44 @@
+You are an expert policy analyst AI assistant tasked with summarizing public consultation responses.
+
+TASK: Analyze all the responses submitted to a consultation's questions and generate a concise narrative summary.
+
+CONSULTATION CONTEXT:
+  - Title: {{CONSULTATION_TITLE}}
+  - Type: {{CONSULTATION_TYPE}}
+  - Department: {{DEPARTMENT_NAME}}
+
+RESPONSES DATA:
+The following are all the responses submitted by citizens/respondents to the consultation's questions. Each response contains question-answer pairs. Clause-specific feedback has been excluded — only direct question responses are included.
+
+{{RESPONSES_DATA}}
+
+OUTPUT LANGUAGE: {{OUTPUT_LANGUAGE}}
+
+SUMMARY INSTRUCTIONS:
+1. Read all responses and identify the dominant themes, points of consensus, points of divergence, and minority viewpoints.
+2. Write the summary in {{OUTPUT_LANGUAGE}}. If the output language is Hindi, write in Devanagari script. If Marathi, write in Devanagari script. If Odia, write in Odia script. If Kannada, write in Kannada script. If English, write in Latin script.
+3. Preserve the substance of respondent opinions — do not inject your own judgments or policy recommendations.
+4. Even if responses are in multiple languages, write the entire summary in {{OUTPUT_LANGUAGE}} only.
+5. Be concise and grounded in what respondents actually said.
+6. Use clear, professional language suitable for government officials and policymakers.
+
+OUTPUT FORMAT:
+Produce a plain-text summary using EXACTLY this structure:
+
+1. An opening paragraph (2-4 sentences) that captures the overall sentiment and the strongest theme across responses.
+
+2. A line starting with the translated equivalent of "Frequently Raised:" in {{OUTPUT_LANGUAGE}}, followed by the points that most respondents agreed on or raised repeatedly, separated by commas.
+
+3. A line starting with the translated equivalent of "Diverging Views:" in {{OUTPUT_LANGUAGE}}, followed by points where respondents disagreed or expressed uncertainty, separated by commas.
+
+4. A line starting with the translated equivalent of "Also Raised:" in {{OUTPUT_LANGUAGE}}, followed by notable minority viewpoints, unique suggestions, or less frequent but worth-noting points, separated by commas.
+
+All four section labels ("Frequently Raised:", "Diverging Views:", "Also Raised:") must be translated into {{OUTPUT_LANGUAGE}}. Only the labels should be translated — the structure must remain the same.
+
+Do not use markdown, headers, bullet points, or JSON. Do not add extra sections beyond the four parts above. Do not add labels like "Summary:" or "Overview:".
+
+EXAMPLE OUTPUT:
+Most respondents welcomed the move to modernise a decades-old rulebook, but the strongest and most consistent theme was payment reliability — many farmers described delays and want stronger enforcement, not just a written rule.
+Frequently Raised: Keeping the Fair and Remunerative Price, the 14-day payment window, and the 15% penalty on delays.
+Diverging Views: Whether penalties will be enforced in practice, and how ethanol is factored into pricing.
+Also Raised: A minority argued the FRP formula still undervalues rising cultivation costs.


### PR DESCRIPTION
Bridge Ticket: [CIV-116](https://bridge.commutatus.com/cm_admin/tasks/CIV-116)

## What does this change do?

Adds AI-generated response summaries for consultations in 5 languages (English, Hindi, Marathi, Odia, Kannada). When a consultation expires, a background job generates narrative summaries from all question responses (excluding clause feedback) using GPT-5.6 Luna via OpenRouter.

## Why is this change needed?

Consultations need automated summaries of public responses to help policymakers quickly understand consensus, diverging views, and minority opinions — without manually reading every response.

## How were the changes done?

- **ConsultationSummaryService** — orchestrates prompt building, LLM calls, and storage. Generates summaries per language with translated section labels.
- **ConsultationSummaryJob** — async job triggered from `Consultation#expire`, calls the service.
- **Prompt template** (`config/prompts/consultation_ai_summary.prompt`) — instructs the AI to produce a 4-part narrative (opening paragraph, Frequently Raised, Diverging Views, Also Raised) with labels translated into the target language.
- **Rich text fields** — `english_response_summary`, `hindi_response_summary`, `marathi_response_summary`, `odia_response_summary`, `kannada_response_summary` on the Consultation model.
- **GraphQL** — exposed all 5 per-language response summary fields as String types with resolvers.
- **JSONB storage** — raw summaries also saved to `response_summary` column as `{ language: text }` hash.

## How was testing done?

Tested end-to-end against consultation #128 in dev — all 5 languages generated correctly with proper scripts (Devanagari, Odia, Kannada) and translated labels.

## AI Code Review Summary

| #   | Severity    | File         | Description | Status     | Notes           |
| --- | ----------- | ------------ | ----------- | ---------- | --------------- |
| 1   | 🟡 Minor    | `base.rb:94-96` | Dead `summary_hindi` resolver method remained after field was removed | ✅ Fixed | Removed dead method |
| 2   | 🟡 Minor    | `base.rb` | `response_summary` JSONB field not exposed in GraphQL | ⏭️ Skipped | Per-language fields are sufficient |

**Blast Radius**: High

<!-- review-and-fix: 3b2a9f890af7c5c24c2fe4cc802f4ab742074171 -->